### PR TITLE
데이터셋 내보내기 선택 기능 추가 및 샘플 데이터 분리

### DIFF
--- a/src/main/kotlin/com/github/ydj515/stdnaminghound/settings/StdNamingHoundConfigurable.kt
+++ b/src/main/kotlin/com/github/ydj515/stdnaminghound/settings/StdNamingHoundConfigurable.kt
@@ -1,6 +1,7 @@
 package com.github.ydj515.stdnaminghound.settings
 
 import com.github.ydj515.stdnaminghound.search.SearchIndexRepository
+import com.github.ydj515.stdnaminghound.storage.DatasetExportService
 import com.github.ydj515.stdnaminghound.storage.DatasetRepository
 import com.github.ydj515.stdnaminghound.storage.MergePolicy
 import com.github.ydj515.stdnaminghound.builder.WordBuilder
@@ -19,7 +20,10 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
+import java.awt.FlowLayout
+import java.io.FileOutputStream
 import javax.swing.JComboBox
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -28,6 +32,7 @@ import javax.swing.JPanel
 class StdNamingHoundConfigurable : Configurable {
     private val settings: StdNamingHoundSettings = ApplicationManager.getApplication().service()
     private val datasetRepository: DatasetRepository = ApplicationManager.getApplication().service()
+    private val datasetExportService: DatasetExportService = ApplicationManager.getApplication().service()
     private val searchIndexRepository: SearchIndexRepository = ApplicationManager.getApplication().service()
     private val validator = CustomDatasetValidator()
 
@@ -42,6 +47,7 @@ class StdNamingHoundConfigurable : Configurable {
     }
     private val mergePolicyCombo = JComboBox(MergePolicy.entries.toTypedArray()).apply {
         minimumSize = java.awt.Dimension(220, minimumSize.height)
+        preferredSize = java.awt.Dimension(220, preferredSize.height)
     }
     private val customJsonArea = JBTextArea().apply {
         lineWrap = true
@@ -51,11 +57,18 @@ class StdNamingHoundConfigurable : Configurable {
     private val loadFileButton = javax.swing.JButton("Import JSON")
     private val downloadSampleButton = javax.swing.JButton("Download Sample")
     private val resetButton = javax.swing.JButton("Reset to Default")
+    private val exportBaseDataButton = javax.swing.JButton("Export Base Data")
 
     /** 설정 UI 컴포넌트를 생성한다. */
     override fun createComponent(): JComponent {
         if (root == null) {
             root = JPanel(BorderLayout())
+            val buttonsPanel = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0)).apply {
+                add(loadFileButton)
+                add(downloadSampleButton)
+                add(resetButton)
+                add(exportBaseDataButton)
+            }
             val content = panel {
                 row {
                     cell(useCustomOnlyCheck)
@@ -83,13 +96,11 @@ class StdNamingHoundConfigurable : Configurable {
                 }
                 row("Preview") {
                     val scroll = JBScrollPane(customJsonArea)
-                    scroll.preferredSize = java.awt.Dimension(600, 240)
+                    scroll.preferredSize = java.awt.Dimension(475, 240)
                     cell(scroll)
                 }
                 row {
-                    cell(loadFileButton)
-                    cell(downloadSampleButton)
-                    cell(resetButton)
+                    cell(buttonsPanel)
                 }
             }
             root?.add(content, BorderLayout.CENTER)
@@ -121,7 +132,7 @@ class StdNamingHoundConfigurable : Configurable {
                 dialog.save(null as java.nio.file.Path?, "std-naming-hound.sample.json") ?: return@addActionListener
             val target = wrapper.file?.toPath()?.toFile()
             val virtualFile = wrapper.virtualFile
-            val content = sampleJson()
+            val content = readResourceText("data/sample.json")
             when {
                 virtualFile != null -> VfsUtil.saveText(virtualFile, content)
                 target != null -> target.writeText(content)
@@ -132,6 +143,10 @@ class StdNamingHoundConfigurable : Configurable {
 
         resetButton.addActionListener {
             customJsonArea.text = ""
+        }
+
+        exportBaseDataButton.addActionListener {
+            exportDatasetZipWithChoice()
         }
 
         return root!!
@@ -200,48 +215,60 @@ class StdNamingHoundConfigurable : Configurable {
         root = null
     }
 
-    /** 샘플 JSON 내용을 반환한다. */
-    private fun sampleJson(): String {
-        return """
-            {
-              "version": "2026.01",
-              "meta": {
-                "dataset_version": "2026.01",
-                "source": "custom",
-                "generated_at": "2026-01-24T12:00:00Z",
-                "counts": { "terms": 1, "words": 1, "domains": 1 }
-              },
-              "terms": [
-                {
-                  "koName": "등록가능여부",
-                  "abbr": "REG_PSBLTY_YN",
-                  "description": "등록 가능한지 여부",
-                  "domainName": "여부C1",
-                  "synonyms": ["등록가능"]
+    private fun exportDatasetZipWithChoice() {
+        val choice = Messages.showDialog(
+            null,
+            "Choose the data to export.\nOriginal (base resources) / Merged (final dataset).",
+            "Export Dataset",
+            arrayOf("Merged", "Original", "Cancel"),
+            0,
+            null
+        )
+        if (choice == 2 || choice == -1) return
+
+        val descriptor = FileSaverDescriptor("Export Dataset", "Save the selected dataset as a ZIP file.", "zip")
+        val dialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, null)
+        val wrapper = dialog.save(null as java.nio.file.Path?, "std-naming-hound-base-data.zip") ?: return
+        try {
+            val virtualFile = wrapper.virtualFile
+            val targetFile = wrapper.file?.toPath()?.toFile()
+            when {
+                virtualFile != null -> {
+                    ApplicationManager.getApplication().runWriteAction {
+                        virtualFile.getOutputStream(this).use { stream ->
+                            writeZip(stream, choice)
+                        }
+                    }
                 }
-              ],
-              "words": [
-                {
-                  "koName": "등록",
-                  "enName": "Registration",
-                  "abbr": "REG",
-                  "description": "등록 행위",
-                  "synonyms": [],
-                  "isFormWord": false
+                targetFile != null -> {
+                    FileOutputStream(targetFile).use { stream ->
+                        writeZip(stream, choice)
+                    }
                 }
-              ],
-              "domains": [
-                {
-                  "name": "여부C1",
-                  "dataType": "CHAR",
-                  "length": 1,
-                  "scale": null,
-                  "storageFormat": "Y/N",
-                  "displayFormat": "Y/N",
-                  "allowedValues": "Y or N"
-                }
-              ]
+                else -> return
             }
-        """.trimIndent()
+            val message = if (choice == 0) {
+                "The merged dataset has been saved as a ZIP file."
+            } else {
+                "The base dataset has been saved as a ZIP file."
+            }
+            Messages.showInfoMessage(message, "Export Complete")
+        } catch (e: Exception) {
+            Messages.showErrorDialog("Failed to save ZIP: ${e.message}", "Export Failed")
+        }
+    }
+
+    private fun writeZip(stream: java.io.OutputStream, choice: Int) {
+        if (choice == 0) {
+            datasetExportService.writeMergedDatasetZip(stream)
+        } else {
+            datasetExportService.writeBaseDatasetZip(stream)
+        }
+    }
+
+    private fun readResourceText(path: String): String {
+        val stream = javaClass.classLoader.getResourceAsStream(path)
+            ?: throw IllegalStateException("리소스를 찾을 수 없습니다: $path")
+        return stream.use { it.readBytes().toString(Charsets.UTF_8) }
     }
 }

--- a/src/main/kotlin/com/github/ydj515/stdnaminghound/settings/StdNamingHoundConfigurable.kt
+++ b/src/main/kotlin/com/github/ydj515/stdnaminghound/settings/StdNamingHoundConfigurable.kt
@@ -138,7 +138,7 @@ class StdNamingHoundConfigurable : Configurable {
                 target != null -> target.writeText(content)
                 else -> return@addActionListener
             }
-            Messages.showInfoMessage("샘플 JSON이 저장되었습니다.", "저장 완료")
+            Messages.showInfoMessage("The sample JSON has been saved.", "Save Complete")
         }
 
         resetButton.addActionListener {

--- a/src/main/kotlin/com/github/ydj515/stdnaminghound/settings/StdNamingHoundConfigurable.kt
+++ b/src/main/kotlin/com/github/ydj515/stdnaminghound/settings/StdNamingHoundConfigurable.kt
@@ -21,6 +21,7 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
+import com.github.ydj515.stdnaminghound.util.readResourceText
 import java.awt.BorderLayout
 import java.awt.FlowLayout
 import java.io.FileOutputStream
@@ -30,6 +31,11 @@ import javax.swing.JPanel
 
 /** 설정 UI를 구성하고 변경 사항을 적용한다. */
 class StdNamingHoundConfigurable : Configurable {
+    private companion object {
+        const val MERGED_CHOICE = 0
+        const val ORIGINAL_CHOICE = 1
+        const val CANCEL_CHOICE = 2
+    }
     private val settings: StdNamingHoundSettings = ApplicationManager.getApplication().service()
     private val datasetRepository: DatasetRepository = ApplicationManager.getApplication().service()
     private val datasetExportService: DatasetExportService = ApplicationManager.getApplication().service()
@@ -224,7 +230,7 @@ class StdNamingHoundConfigurable : Configurable {
             0,
             null
         )
-        if (choice == 2 || choice == -1) return
+        if (choice == CANCEL_CHOICE || choice == -1) return
 
         val descriptor = FileSaverDescriptor("Export Dataset", "Save the selected dataset as a ZIP file.", "zip")
         val dialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, null)
@@ -247,7 +253,7 @@ class StdNamingHoundConfigurable : Configurable {
                 }
                 else -> return
             }
-            val message = if (choice == 0) {
+            val message = if (choice == MERGED_CHOICE) {
                 "The merged dataset has been saved as a ZIP file."
             } else {
                 "The base dataset has been saved as a ZIP file."
@@ -259,16 +265,11 @@ class StdNamingHoundConfigurable : Configurable {
     }
 
     private fun writeZip(stream: java.io.OutputStream, choice: Int) {
-        if (choice == 0) {
+        if (choice == MERGED_CHOICE) {
             datasetExportService.writeMergedDatasetZip(stream)
         } else {
             datasetExportService.writeBaseDatasetZip(stream)
         }
     }
 
-    private fun readResourceText(path: String): String {
-        val stream = javaClass.classLoader.getResourceAsStream(path)
-            ?: throw IllegalStateException("리소스를 찾을 수 없습니다: $path")
-        return stream.use { it.readBytes().toString(Charsets.UTF_8) }
-    }
 }

--- a/src/main/kotlin/com/github/ydj515/stdnaminghound/storage/DatasetExportService.kt
+++ b/src/main/kotlin/com/github/ydj515/stdnaminghound/storage/DatasetExportService.kt
@@ -1,0 +1,53 @@
+package com.github.ydj515.stdnaminghound.storage
+
+import com.google.gson.GsonBuilder
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import java.io.BufferedOutputStream
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/** 데이터셋을 ZIP으로 내보내는 책임을 담당한다. */
+@Service(Service.Level.APP)
+class DatasetExportService {
+    private val datasetRepository = service<DatasetRepository>()
+    private val gson = GsonBuilder().setPrettyPrinting().create()
+
+    fun writeBaseDatasetZip(stream: OutputStream) {
+        ZipOutputStream(BufferedOutputStream(stream)).use { zip ->
+            val resources = listOf(
+                "data/domains.json",
+                "data/terms.json",
+                "data/words.json",
+            )
+            for (path in resources) {
+                val bytes = readResourceBytes(path)
+                val entryName = path.substringAfterLast('/')
+                writeZipEntry(zip, entryName, bytes)
+            }
+        }
+    }
+
+    fun writeMergedDatasetZip(stream: OutputStream) {
+        ZipOutputStream(BufferedOutputStream(stream)).use { zip ->
+            val dataset = datasetRepository.getDataset()
+            writeZipEntry(zip, "terms.json", gson.toJson(dataset.terms).toByteArray(StandardCharsets.UTF_8))
+            writeZipEntry(zip, "words.json", gson.toJson(dataset.words).toByteArray(StandardCharsets.UTF_8))
+            writeZipEntry(zip, "domains.json", gson.toJson(dataset.domains).toByteArray(StandardCharsets.UTF_8))
+        }
+    }
+
+    private fun readResourceBytes(path: String): ByteArray {
+        val stream = javaClass.classLoader.getResourceAsStream(path)
+            ?: throw IllegalStateException("리소스를 찾을 수 없습니다: $path")
+        return stream.use { it.readBytes() }
+    }
+
+    private fun writeZipEntry(zip: ZipOutputStream, name: String, bytes: ByteArray) {
+        zip.putNextEntry(ZipEntry(name))
+        zip.write(bytes)
+        zip.closeEntry()
+    }
+}

--- a/src/main/kotlin/com/github/ydj515/stdnaminghound/storage/DatasetExportService.kt
+++ b/src/main/kotlin/com/github/ydj515/stdnaminghound/storage/DatasetExportService.kt
@@ -3,6 +3,7 @@ package com.github.ydj515.stdnaminghound.storage
 import com.google.gson.GsonBuilder
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
+import com.github.ydj515.stdnaminghound.util.readResourceBytes
 import java.io.BufferedOutputStream
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
@@ -12,15 +13,23 @@ import java.util.zip.ZipOutputStream
 /** 데이터셋을 ZIP으로 내보내는 책임을 담당한다. */
 @Service(Service.Level.APP)
 class DatasetExportService {
+    private companion object {
+        const val DOMAINS_RESOURCE = "data/domains.json"
+        const val TERMS_RESOURCE = "data/terms.json"
+        const val WORDS_RESOURCE = "data/words.json"
+        const val DOMAINS_FILE = "domains.json"
+        const val TERMS_FILE = "terms.json"
+        const val WORDS_FILE = "words.json"
+    }
     private val datasetRepository = service<DatasetRepository>()
     private val gson = GsonBuilder().setPrettyPrinting().create()
 
     fun writeBaseDatasetZip(stream: OutputStream) {
         ZipOutputStream(BufferedOutputStream(stream)).use { zip ->
             val resources = listOf(
-                "data/domains.json",
-                "data/terms.json",
-                "data/words.json",
+                DOMAINS_RESOURCE,
+                TERMS_RESOURCE,
+                WORDS_RESOURCE,
             )
             for (path in resources) {
                 val bytes = readResourceBytes(path)
@@ -33,16 +42,10 @@ class DatasetExportService {
     fun writeMergedDatasetZip(stream: OutputStream) {
         ZipOutputStream(BufferedOutputStream(stream)).use { zip ->
             val dataset = datasetRepository.getDataset()
-            writeZipEntry(zip, "terms.json", gson.toJson(dataset.terms).toByteArray(StandardCharsets.UTF_8))
-            writeZipEntry(zip, "words.json", gson.toJson(dataset.words).toByteArray(StandardCharsets.UTF_8))
-            writeZipEntry(zip, "domains.json", gson.toJson(dataset.domains).toByteArray(StandardCharsets.UTF_8))
+            writeZipEntry(zip, TERMS_FILE, gson.toJson(dataset.terms).toByteArray(StandardCharsets.UTF_8))
+            writeZipEntry(zip, WORDS_FILE, gson.toJson(dataset.words).toByteArray(StandardCharsets.UTF_8))
+            writeZipEntry(zip, DOMAINS_FILE, gson.toJson(dataset.domains).toByteArray(StandardCharsets.UTF_8))
         }
-    }
-
-    private fun readResourceBytes(path: String): ByteArray {
-        val stream = javaClass.classLoader.getResourceAsStream(path)
-            ?: throw IllegalStateException("리소스를 찾을 수 없습니다: $path")
-        return stream.use { it.readBytes() }
     }
 
     private fun writeZipEntry(zip: ZipOutputStream, name: String, bytes: ByteArray) {

--- a/src/main/kotlin/com/github/ydj515/stdnaminghound/toolWindow/ui/ToolWindowUiBuilder.kt
+++ b/src/main/kotlin/com/github/ydj515/stdnaminghound/toolWindow/ui/ToolWindowUiBuilder.kt
@@ -62,7 +62,7 @@ class ToolWindowUiBuilder {
         domainCombo.preferredSize = JBUI.size(JBUI.scale(165), domainCombo.preferredSize.height)
         domainCombo.maximumSize = JBUI.size(JBUI.scale(165), domainCombo.preferredSize.height)
         val previewHeight = JBUI.scale(24)
-        builderPreview.preferredSize = JBUI.size(JBUI.scale(220), previewHeight)
+        builderPreview.preferredSize = JBUI.size(JBUI.scale(180), previewHeight)
         builderPreview.minimumSize = JBUI.size(JBUI.scale(120), previewHeight)
         builderPreview.maximumSize = java.awt.Dimension(Int.MAX_VALUE, previewHeight)
         val builderClearButton = JButton(AllIcons.Actions.GC).apply { toolTipText = "Clear Builder" }

--- a/src/main/kotlin/com/github/ydj515/stdnaminghound/util/ResourceLoader.kt
+++ b/src/main/kotlin/com/github/ydj515/stdnaminghound/util/ResourceLoader.kt
@@ -1,0 +1,15 @@
+package com.github.ydj515.stdnaminghound.util
+
+private object ResourceLoader
+
+/** 클래스패스 리소스를 읽는 공통 유틸리티다. */
+fun readResourceBytes(path: String): ByteArray {
+    val stream = ResourceLoader::class.java.classLoader.getResourceAsStream(path)
+        ?: throw IllegalStateException("리소스를 찾을 수 없습니다: $path")
+    return stream.use { it.readBytes() }
+}
+
+/** 클래스패스 리소스를 UTF-8 텍스트로 읽는다. */
+fun readResourceText(path: String): String {
+    return readResourceBytes(path).toString(Charsets.UTF_8)
+}

--- a/src/main/resources/data/sample.json
+++ b/src/main/resources/data/sample.json
@@ -1,0 +1,39 @@
+{
+  "version": "2026.01",
+  "meta": {
+    "dataset_version": "2026.01",
+    "source": "custom",
+    "generated_at": "2026-01-24T12:00:00Z",
+    "counts": { "terms": 1, "words": 1, "domains": 1 }
+  },
+  "terms": [
+    {
+      "koName": "등록가능여부",
+      "abbr": "REG_PSBLTY_YN",
+      "description": "등록 가능한지 여부",
+      "domainName": "여부C1",
+      "synonyms": ["등록가능"]
+    }
+  ],
+  "words": [
+    {
+      "koName": "등록",
+      "enName": "Registration",
+      "abbr": "REG",
+      "description": "등록 행위",
+      "synonyms": [],
+      "isFormWord": false
+    }
+  ],
+  "domains": [
+    {
+      "name": "여부C1",
+      "dataType": "CHAR",
+      "length": 1,
+      "scale": null,
+      "storageFormat": "Y/N",
+      "displayFormat": "Y/N",
+      "allowedValues": "Y or N"
+    }
+  ]
+}


### PR DESCRIPTION
  - 내보내기 시 원본/병합 데이터 선택 후 ZIP으로 저장하는 기능 추가
  - 내보내기 로직을 전용 서비스로 분리하여 확장성 확보
  - 샘플 JSON을 리소스로 분리하고 클래스패스로 로딩
  - 설정 UI 일부 폭/정렬 조정 및 내보내기 관련 메시지 영문화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export datasets as ZIP with a choice of merged or original data from the settings UI.
  * New Export button added alongside Import, Download and Reset actions.

* **Improvements**
  * Added sample dataset resource for export and updated sample save messaging.
  * Tweaked UI layout and component sizing for improved preview and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->